### PR TITLE
Add project creation UI and simplify auth store

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -2,5 +2,8 @@
 module.exports = {
     testEnvironment: 'jsdom',
     testMatch: ['**/__tests__/**/*.test.tsx'],
-    setupFilesAfterEnv: ['<rootDir>/jest.setup.ts']
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+    transform: {
+        '^.+\\.(t|j)sx?$': ['babel-jest', { presets: ['next/babel'] }]
+    }
 };

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -18,7 +18,7 @@ export default function DashboardPage() {
       <h1 className="text-2xl font-semibold">Welcome, {user?.name}</h1>
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-medium">Projects</h2>
-        <Link className="px-3 py-2 border rounded" href="/dashboard">+ New</Link>
+        <Link className="px-3 py-2 border rounded" href="/dashboard/projects/new">+ New</Link>
       </div>
       {isLoading && <p>Loading...</p>}
       <ul className="grid gap-3 md:grid-cols-2">

--- a/frontend/src/app/dashboard/projects/new/page.tsx
+++ b/frontend/src/app/dashboard/projects/new/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '../../../../store/auth.store';
+import { useCreateProject } from '../../../../hooks/use-projects';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+const schema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  description: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export default function NewProjectPage() {
+  const { isAuthed } = useAuthStore();
+  const router = useRouter();
+  useEffect(() => {
+    if (!isAuthed()) router.push('/login');
+  }, [isAuthed, router]);
+
+  const createProject = useCreateProject();
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormValues>({ resolver: zodResolver(schema) });
+
+  if (!isAuthed()) return null;
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      await createProject.mutateAsync(values);
+      router.push('/dashboard');
+    } catch (e: any) {
+      alert(e?.response?.data?.error || 'Failed to create project');
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto space-y-6">
+      <h1 className="text-2xl font-semibold">New Project</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label className="block mb-1">Name</label>
+          <input className="w-full border rounded px-3 py-2" {...register('name')} />
+          {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+        </div>
+        <div>
+          <label className="block mb-1">Description</label>
+          <textarea className="w-full border rounded px-3 py-2" {...register('description')} />
+          {errors.description && <p className="text-sm text-red-600">{errors.description.message}</p>}
+        </div>
+        <button className="px-4 py-2 bg-black text-white rounded disabled:opacity-50" disabled={isSubmitting}>Create</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -18,7 +18,7 @@ export default function LoginPage() {
   const onSubmit = async (values: FormValues) => {
     try {
       const res = await loginApi(values.email, values.password);
-      setAuth(res.accessToken, res.refreshToken, res.user);
+      setAuth(res.accessToken, res.user);
       router.push('/dashboard');
     } catch (e: any) {
       alert(e?.response?.data?.error || 'Login failed');

--- a/frontend/src/hooks/use-projects.ts
+++ b/frontend/src/hooks/use-projects.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '../lib/api';
 
 export type Project = { id: string; name: string; description?: string; createdAt: string; };
@@ -11,5 +11,16 @@ export function useProjects() {
       const { data } = await api.get<Project[]>('/projects');
       return data;
     }
+  });
+}
+
+export function useCreateProject() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: { name: string; description?: string }) =>
+      (await api.post('/projects', payload)).data,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['projects'] });
+    },
   });
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -44,7 +44,10 @@ api.interceptors.response.use((res) => res, async (error) => {
 
 export default api;
 
-export async function loginApi(email: string, password: string) {
+export async function loginApi(
+  email: string,
+  password: string
+): Promise<{ accessToken: string; user: { id: string; email: string; name: string } }> {
   const res = await api.post('/auth/login', { email, password });
   return res.data;
 }

--- a/frontend/src/store/auth.store.ts
+++ b/frontend/src/store/auth.store.ts
@@ -5,9 +5,8 @@ import { persist } from 'zustand/middleware';
 type User = { id: string; email: string; name: string };
 type AuthState = {
   accessToken: string | null;
-  refreshToken: string | null;
   user: User | null;
-  setAuth: (accessToken: string, refreshToken: string, user: User) => void;
+  setAuth: (accessToken: string, user: User) => void;
   setAccessToken: (t: string) => void;
   logout: () => void;
   isAuthed: () => boolean;
@@ -15,10 +14,9 @@ type AuthState = {
 
 export const useAuthStore = create<AuthState>()(persist((set, get) => ({
   accessToken: null,
-  refreshToken: null,
   user: null,
-  setAuth: (accessToken, refreshToken, user) => set({ accessToken, refreshToken, user }),
+  setAuth: (accessToken, user) => set({ accessToken, user }),
   setAccessToken: (t) => set({ accessToken: t }),
-  logout: () => set({ accessToken: null, refreshToken: null, user: null }),
+  logout: () => set({ accessToken: null, user: null }),
   isAuthed: () => !!get().accessToken,
 }), { name: 'auth-store' }));


### PR DESCRIPTION
## Summary
- enable project creation via new dashboard form
- simplify auth store and login flow
- configure Jest to compile TypeScript tests

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac503e58c4832cbf15e1b03c7ef03f